### PR TITLE
Add method for lookup by id

### DIFF
--- a/lib/omdb/api.rb
+++ b/lib/omdb/api.rb
@@ -24,7 +24,7 @@ module Omdb
       res = network.call({t: title, y: year, tomatoes: tomatoes, plot: plot})
       
       if res[:data]["Response"] == "False"
-        response = {:status => 404}
+        response = {status: 404}
       else
         response = {
           status: res[:code],
@@ -40,7 +40,7 @@ module Omdb
       res = network.call({i: id, tomatoes: tomatoes, plot: plot})
       
       if res[:data]["Response"] == "False"
-        response = {:status => 404}
+        response = {status: 404}
       else
         response = {
           status: res[:code],

--- a/lib/omdb/api.rb
+++ b/lib/omdb/api.rb
@@ -32,6 +32,22 @@ module Omdb
         }
       end
     end
+    
+    # fetches a movie by IMDB id
+    # set tomatoes to true if you want to get the rotten tomatoes ranking
+    # set plot to full if you want to have the full, long plot
+    def find(id, tomatoes = false, plot = "short")
+      res = network.call({i: id, tomatoes: tomatoes, plot: plot})
+      
+      if res[:data]["Response"] == "False"
+        response = {:status => 404}
+      else
+        response = {
+          status: res[:code],
+          movie: parse_movie(res[:data])
+        }
+      end
+    end
 
     private
     def parse_movies(json_string)

--- a/spec/lib/omdb/api_spec.rb
+++ b/spec/lib/omdb/api_spec.rb
@@ -62,6 +62,22 @@ describe 'Omdb::Api' do
     end
   end
 
+  describe 'Finding a movie by IMDB ID' do
+    context "When searching for 'Star Wars' by ID" do
+      it "has status code 200" do
+        expect(movie_fetch[:status]).to eq(200)
+      end
+
+      it "has a movie object" do
+        expect(movie_fetch[:movie]).to be_a(Omdb::Movie)
+      end
+
+      it "has a title 'Star Wars'" do
+        expect(movie_find[:movie].title).to eq("Star Wars")
+      end
+    end
+  end
+
   def do_movie_search
     omdb_return_data = File.read(File.join("spec", "fixtures", "movies_search.json"))
     stub_request(:any, /.*www.omdbapi.com.*/).to_return(body: omdb_return_data, status: 200 )
@@ -84,6 +100,12 @@ describe 'Omdb::Api' do
     omdb_return_data = File.read(File.join("spec", "fixtures", "no_results.json"))
     stub_request(:any, /.*www.omdbapi.com.*/).to_return(body: omdb_return_data, status: 200)
     Omdb::Api.new.fetch("Search term")
+  end
+
+  def movie_find
+    omdb_return_data = File.read(File.join("spec", "fixtures", "star_wars.json"))
+    stub_request(:any, /.*www.omdbapi.com.*/).to_return(body: omdb_return_data, status: 200)
+    Omdb::Api.new.find("tt0076759")
   end
 end
 

--- a/spec/lib/omdb/network_spec.rb
+++ b/spec/lib/omdb/network_spec.rb
@@ -28,6 +28,14 @@ describe Omdb::Network do
       end
     end
 
+    context 'When called with {i: "tt0076759"} as params' do
+      it 'returns value contains "Star Wars"' do
+        expect(find_movie[:data]).to include(
+          {"Title" => "Star Wars"}
+        )
+      end
+    end
+
     def search_movie
       omdb_return_data = File.read(File.join("spec", "fixtures", "movies_search.json"))
       stub_request(:any, "http://www.omdbapi.com").
@@ -42,6 +50,14 @@ describe Omdb::Network do
         with({query: {"t" => "Star Wars"}}).
         to_return(body: omdb_return_data, status: 200 )
       Omdb::Network.new.call({t: "Star Wars"})
+    end
+
+    def find_movie
+      omdb_return_data = File.read(File.join("spec", "fixtures", "star_wars.json"))
+      stub_request(:any, "http://www.omdbapi.com").
+        with({query: {"i" => "tt0076759"}}).
+        to_return(body: omdb_return_data, status: 200 )
+      Omdb::Network.new.call({i: "tt0076759"})
     end
   end
 end


### PR DESCRIPTION
The `fetch` method can be dangerous since there can be more than one item with the same title, so I needed an id lookup method for my project.

Here it is under `find` if you want it.